### PR TITLE
PI-1815: update to S3 Maven repo and TAR v2.1.2

### DIFF
--- a/Sheppard/build.gradle
+++ b/Sheppard/build.gradle
@@ -5,7 +5,7 @@ android {
     defaultConfig {
         applicationId "com.truex.sheppard"
         minSdkVersion 25
-        targetSdkVersion 26
+        targetSdkVersion 30
         versionCode 1
         versionName "2.0"
     }

--- a/Sheppard/build.gradle
+++ b/Sheppard/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 30
     defaultConfig {
         applicationId "com.truex.sheppard"
         minSdkVersion 25
@@ -32,7 +32,7 @@ android {
 
 repositories {
     maven {
-        url "https://raw.github.com/socialvibe/truex-tv-integrations/android"
+        url "https://ctv.truex.com/android/maven"
     }
 }
 
@@ -40,8 +40,8 @@ dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation 'androidx.appcompat:appcompat:1.0.0-beta01'
     implementation 'com.google.android.exoplayer:exoplayer:2.6.1'
-    // implementation 'com.truex:TruexAdRenderer-tv:2.1.0'
+    implementation 'com.truex:TruexAdRenderer-tv:2.1.1'
 
     // True[x] Ad Renderer (TAR) Dependency
-    implementation project(':TruexAdRenderer')
+    // implementation project(':TruexAdRenderer')
 }

--- a/Sheppard/build.gradle
+++ b/Sheppard/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 28
     defaultConfig {
         applicationId "com.truex.sheppard"
         minSdkVersion 21

--- a/Sheppard/build.gradle
+++ b/Sheppard/build.gradle
@@ -38,10 +38,8 @@ repositories {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation 'androidx.appcompat:appcompat:1.0.0-beta01'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'com.google.android.exoplayer:exoplayer:2.6.1'
-    implementation 'com.truex:TruexAdRenderer-tv:2.1.1'
-
     // True[x] Ad Renderer (TAR) Dependency
-    // implementation project(':TruexAdRenderer')
+    implementation 'com.truex:TruexAdRenderer-tv:2.1.2'
 }

--- a/Sheppard/build.gradle
+++ b/Sheppard/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
     defaultConfig {
         applicationId "com.truex.sheppard"
-        minSdkVersion 21
+        minSdkVersion 25
         targetSdkVersion 26
         versionCode 1
         versionName "2.0"
@@ -38,7 +38,10 @@ repositories {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation 'com.android.support:appcompat-v7:26.1.0'
+    implementation 'androidx.appcompat:appcompat:1.0.0-beta01'
     implementation 'com.google.android.exoplayer:exoplayer:2.6.1'
-    implementation 'com.truex:TruexAdRenderer-tv:2.1.0'
+    // implementation 'com.truex:TruexAdRenderer-tv:2.1.0'
+
+    // True[x] Ad Renderer (TAR) Dependency
+    implementation project(':TruexAdRenderer')
 }

--- a/Sheppard/src/main/AndroidManifest.xml
+++ b/Sheppard/src/main/AndroidManifest.xml
@@ -17,6 +17,9 @@
         android:label="@string/app_name"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
+        <meta-data
+            android:name="com.google.android.gms.ads.AD_MANAGER_APP"
+            android:value="true"/>
         <activity
             android:name=".MainActivity"
             android:banner="@drawable/app_icon"

--- a/Sheppard/src/main/java/com/truex/sheppard/MainActivity.java
+++ b/Sheppard/src/main/java/com/truex/sheppard/MainActivity.java
@@ -1,7 +1,7 @@
 package com.truex.sheppard;
 
 import android.net.Uri;
-import android.support.v7.app.AppCompatActivity;
+import androidx.appcompat.app.AppCompatActivity;
 import android.os.Bundle;
 import android.util.Log;
 import android.view.View;

--- a/Sheppard/src/main/java/com/truex/sheppard/ads/TruexAdManager.java
+++ b/Sheppard/src/main/java/com/truex/sheppard/ads/TruexAdManager.java
@@ -4,7 +4,7 @@ import android.content.Context;
 import android.util.Log;
 import android.view.ViewGroup;
 
-import com.truex.adrenderer.IEventHandler;
+import com.truex.adrenderer.IEventEmitter.IEventHandler;
 import com.truex.adrenderer.TruexAdRenderer;
 import com.truex.adrenderer.TruexAdRendererConstants;
 import com.truex.sheppard.player.PlaybackHandler;
@@ -54,7 +54,7 @@ public class TruexAdManager {
      */
     public void startAd(ViewGroup viewGroup) {
         try {
-            String json = String.format("{\"user_id\":\"3e47e82244f7aa7ac3fa60364a7ede8453f3f9fe\",\"placement_hash\":\"%s\",\"vast_config_url\":\"%s\"}\n", "81551ffa2b851abc5372ab9ed9f1f58adabe5203", "http://qa-get.truex.com/81551ffa2b851abc5372ab9ed9f1f58adabe5203/vast/config?asnw=&flag=%2Bamcb%2Bemcr%2Bslcb%2Bvicb%2Baeti-exvt&fw_key_values=&metr=0&prof=g_as3_truex&ptgt=a&pvrn=&resp=vmap1&slid=fw_truex&ssnw=&vdur=&vprn=");
+            String json = String.format("{\"user_id\":\"3e47e82244f7aa7ac3fa60364a7ede8453f3f9fe\",\"placement_hash\":\"%s\",\"vast_config_url\":\"%s\"}\n", "d3bfc4a1c2f31ab987f2725a5ed03c9ae5837887", "http://get.truex.com/d3bfc4a1c2f31ab987f2725a5ed03c9ae5837887/vast/config?asnw=&flag=%2Bamcb%2Bemcr%2Bslcb%2Bvicb%2Baeti-exvt&fw_key_values=&metr=0&prof=g_as3_truex&ptgt=a&pvrn=&resp=vmap1&slid=fw_truex&ssnw=&vdur=&vprn=");
             JSONObject adParams = new JSONObject(json);
 
             truexAdRenderer.init(adParams, TruexAdRendererConstants.PREROLL);

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.3.2'
-
+        classpath 'digital.wup:android-maven-publish:3.6.2'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,8 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
+android.enableJetifier=true
+android.useAndroidX=true
 org.gradle.jvmargs=-Xmx1536m
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,3 @@
 include ':Sheppard'
+include ':TruexAdRenderer'
+project(':TruexAdRenderer').projectDir = new File(settingsDir, '../TruexAdRenderer-Android/TruexAdRenderer')

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,1 @@
 include ':Sheppard'
-//include ':TruexAdRenderer'
-//project(':TruexAdRenderer').projectDir = new File(settingsDir, '../TruexAdRenderer-Android/TruexAdRenderer')

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,3 @@
 include ':Sheppard'
-include ':TruexAdRenderer'
-project(':TruexAdRenderer').projectDir = new File(settingsDir, '../TruexAdRenderer-Android/TruexAdRenderer')
+//include ':TruexAdRenderer'
+//project(':TruexAdRenderer').projectDir = new File(settingsDir, '../TruexAdRenderer-Android/TruexAdRenderer')


### PR DESCRIPTION
These are the changes to upgrade `sheppard` to TAR v2.1.2 and the new Maven repo.

It includes migration to AndroidX which was kind of forced by conflicting Google libs from TAR's own AndroidX migration.

It has the change to IEventHandler reflecting its refactor in TAR.

We also move `sheppard` to pull from the reference app placement in production, which is a more stable base to support development short term until we go to v2.2.0 on the HTML5 baseline.

I did lightly dev test and validated a build from a clean gradle cache.