### PR TITLE
PI-1820: Fire TV - Reference apps don't work with API level 30 (SSL issues)

### DIFF
--- a/Sheppard/build.gradle
+++ b/Sheppard/build.gradle
@@ -41,5 +41,5 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'com.google.android.exoplayer:exoplayer:2.10.5'
     // True[x] Ad Renderer (TAR) Dependency
-    implementation 'com.truex:TruexAdRenderer-tv:2.1.2'
+    implementation 'com.truex:TruexAdRenderer-tv:2.1.3'
 }

--- a/Sheppard/build.gradle
+++ b/Sheppard/build.gradle
@@ -39,7 +39,7 @@ repositories {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'com.google.android.exoplayer:exoplayer:2.6.1'
+    implementation 'com.google.android.exoplayer:exoplayer:2.10.5'
     // True[x] Ad Renderer (TAR) Dependency
     implementation 'com.truex:TruexAdRenderer-tv:2.1.2'
 }

--- a/Sheppard/src/main/AndroidManifest.xml
+++ b/Sheppard/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        android:usesCleartextTraffic="true">
         <meta-data
             android:name="com.google.android.gms.ads.AD_MANAGER_APP"
             android:value="true"/>

--- a/Sheppard/src/main/java/com/truex/sheppard/MainActivity.java
+++ b/Sheppard/src/main/java/com/truex/sheppard/MainActivity.java
@@ -10,19 +10,18 @@ import android.view.Window;
 import android.view.WindowManager;
 
 import com.google.android.exoplayer2.ExoPlayerFactory;
+import com.google.android.exoplayer2.Player;
 import com.google.android.exoplayer2.SimpleExoPlayer;
 import com.google.android.exoplayer2.source.ConcatenatingMediaSource;
-import com.google.android.exoplayer2.source.ExtractorMediaSource;
 import com.google.android.exoplayer2.source.MediaSource;
+import com.google.android.exoplayer2.source.ProgressiveMediaSource;
 import com.google.android.exoplayer2.trackselection.AdaptiveTrackSelection;
 import com.google.android.exoplayer2.trackselection.DefaultTrackSelector;
 import com.google.android.exoplayer2.trackselection.TrackSelection;
-import com.google.android.exoplayer2.ui.SimpleExoPlayerView;
-import com.google.android.exoplayer2.upstream.BandwidthMeter;
 import com.google.android.exoplayer2.upstream.DataSource;
-import com.google.android.exoplayer2.upstream.DefaultBandwidthMeter;
 import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
 import com.google.android.exoplayer2.util.Util;
+import com.google.android.exoplayer2.ui.PlayerView;
 import com.truex.sheppard.ads.TruexAdManager;
 import com.truex.sheppard.player.DisplayMode;
 import com.truex.sheppard.player.PlaybackHandler;
@@ -37,7 +36,7 @@ public class MainActivity extends AppCompatActivity implements PlaybackStateList
     private static final String AD_URL_THREE = "http://media.truex.com/file_assets/2019-01-30/742eb926-6ec0-48b4-b1e6-093cee334dd1.mp4";
 
     // This player view is used to display a fake stream that mimics actual video content
-    private SimpleExoPlayerView playerView;
+    private PlayerView playerView;
 
     // The data-source factory is used to build media-sources
     private DataSource.Factory dataSourceFactory;
@@ -176,7 +175,7 @@ public class MainActivity extends AppCompatActivity implements PlaybackStateList
         if (playerView.getPlayer() == null) {
             return;
         }
-        SimpleExoPlayer player = playerView.getPlayer();
+        Player player = playerView.getPlayer();
         playerView.setPlayer(null);
         player.release();
     }
@@ -202,12 +201,12 @@ public class MainActivity extends AppCompatActivity implements PlaybackStateList
 
         for(int i = 0; i < ads.length; i++) {
             Uri uri = Uri.parse(adUrls[i]);
-            MediaSource source = new ExtractorMediaSource.Factory(dataSourceFactory).createMediaSource(uri);
+            MediaSource source = new ProgressiveMediaSource.Factory(dataSourceFactory).createMediaSource(uri);
             ads[i] = source;
         }
 
         MediaSource adPod = new ConcatenatingMediaSource(ads);
-        playerView.getPlayer().prepare(adPod);
+        ((SimpleExoPlayer)playerView.getPlayer()).prepare(adPod);
         playerView.getPlayer().setPlayWhenReady(true);
         playerView.setVisibility(View.VISIBLE);
     }
@@ -238,14 +237,13 @@ public class MainActivity extends AppCompatActivity implements PlaybackStateList
         displayMode = DisplayMode.CONTENT_STREAM;
 
         Uri uri = Uri.parse(CONTENT_STREAM_URL);
-        MediaSource source = new ExtractorMediaSource.Factory(dataSourceFactory).createMediaSource(uri);
-        playerView.getPlayer().prepare(source);
+        MediaSource source = new ProgressiveMediaSource.Factory(dataSourceFactory).createMediaSource(uri);
+        ((SimpleExoPlayer)playerView.getPlayer()).prepare(source);
         playerView.getPlayer().setPlayWhenReady(true);
     }
 
     private void setupExoPlayer() {
-        BandwidthMeter bandwidthMeter = new DefaultBandwidthMeter();
-        TrackSelection.Factory trackSelectionFactory = new AdaptiveTrackSelection.Factory(bandwidthMeter);
+        TrackSelection.Factory trackSelectionFactory = new AdaptiveTrackSelection.Factory();
         DefaultTrackSelector trackSelector = new DefaultTrackSelector(trackSelectionFactory);
         SimpleExoPlayer player = ExoPlayerFactory.newSimpleInstance(this, trackSelector);
 

--- a/Sheppard/src/main/java/com/truex/sheppard/ads/TruexAdManager.java
+++ b/Sheppard/src/main/java/com/truex/sheppard/ads/TruexAdManager.java
@@ -54,7 +54,7 @@ public class TruexAdManager {
      */
     public void startAd(ViewGroup viewGroup) {
         try {
-            String json = String.format("{\"user_id\":\"3e47e82244f7aa7ac3fa60364a7ede8453f3f9fe\",\"placement_hash\":\"%s\",\"vast_config_url\":\"%s\"}\n", "d3bfc4a1c2f31ab987f2725a5ed03c9ae5837887", "http://get.truex.com/d3bfc4a1c2f31ab987f2725a5ed03c9ae5837887/vast/config?asnw=&flag=%2Bamcb%2Bemcr%2Bslcb%2Bvicb%2Baeti-exvt&fw_key_values=&metr=0&prof=g_as3_truex&ptgt=a&pvrn=&resp=vmap1&slid=fw_truex&ssnw=&vdur=&vprn=");
+            String json = String.format("{\"user_id\":\"3e47e82244f7aa7ac3fa60364a7ede8453f3f9fe\",\"placement_hash\":\"%s\",\"vast_config_url\":\"%s\"}\n", "d3bfc4a1c2f31ab987f2725a5ed03c9ae5837887", "https://get.truex.com/d3bfc4a1c2f31ab987f2725a5ed03c9ae5837887/vast/config?asnw=&flag=%2Bamcb%2Bemcr%2Bslcb%2Bvicb%2Baeti-exvt&fw_key_values=&metr=0&prof=g_as3_truex&ptgt=a&pvrn=&resp=vmap1&slid=fw_truex&ssnw=&vdur=&vprn=");
             JSONObject adParams = new JSONObject(json);
 
             truexAdRenderer.init(adParams, TruexAdRendererConstants.PREROLL);

--- a/Sheppard/src/main/res/xml/network_security_config.xml
+++ b/Sheppard/src/main/res/xml/network_security_config.xml
@@ -6,4 +6,7 @@
             <certificates src="user" />
         </trust-anchors>
     </debug-overrides>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">media.truex.com</domain>
+    </domain-config>
 </network-security-config>


### PR DESCRIPTION
**v2.1.3 update**: the transition to API level 30 meant a lot of stuff utilizing HTTPS started breaking. Namely, the video streams used by the app for the flow failed to play in ExoPlayer, with error messages complaining about a missing link in the trust chain, or some such. Well, the `media.truex.com` S3 end point we're using is certainly legit from an SSL standpoint (verified in `https://www.digicert.com/help/`). Googling around, I couldn't figure out why there would be a problem playing this stream, while pulling the true[X] tag's vast/config in HTTPS works in the same app. 

In `sheppard` I also tried to update the version of ExoPlayer, to no avail.

In the end I decided to whitelist the test videos for insecure playback. But I validated that this app works with the updated TAR that forces unqualified tags to use HTTPS instead of HTTP. See [PI-1820](https://truextech.atlassian.net/browse/PI-1820).

I tested in the emulator as well as on device.