### PR TITLE
Update TAR-Android dependency to 2.2.0

### DIFF
--- a/Sheppard/build.gradle
+++ b/Sheppard/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.application'
+apply plugin: 'maven-publish'
 
 android {
     compileSdkVersion 30
@@ -41,5 +42,5 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'com.google.android.exoplayer:exoplayer:2.10.5'
     // True[x] Ad Renderer (TAR) Dependency
-    implementation 'com.truex:TruexAdRenderer-tv:2.1.3'
+    implementation 'com.truex:TruexAdRenderer-tv:2.2.0'
 }


### PR DESCRIPTION
Now compiles and runs with the latest TAR-Android version (v2.2.0). I'm getting no ads on the VAST response, it's hard-coded and I'm looking for a replacement.