### PR TITLE
CTV-2261: migrate Sheppard to correct Maven repo, TAR version, and test tag

### DIFF
--- a/Sheppard/build.gradle
+++ b/Sheppard/build.gradle
@@ -32,7 +32,7 @@ android {
 
 repositories {
     maven {
-        url "https://ctv.truex.com/android/maven"
+        url "https://s3.amazonaws.com/android.truex.com/maven"
     }
 }
 
@@ -41,5 +41,5 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'com.google.android.exoplayer:exoplayer:2.10.5'
     // True[x] Ad Renderer (TAR) Dependency
-    implementation 'com.truex:TruexAdRenderer-tv:2.1.3'
+    implementation 'com.truex:TruexAdRenderer-tv:2.2.1'
 }

--- a/Sheppard/src/main/java/com/truex/sheppard/ads/TruexAdManager.java
+++ b/Sheppard/src/main/java/com/truex/sheppard/ads/TruexAdManager.java
@@ -54,7 +54,7 @@ public class TruexAdManager {
      */
     public void startAd(ViewGroup viewGroup) {
         try {
-            String json = String.format("{\"user_id\":\"3e47e82244f7aa7ac3fa60364a7ede8453f3f9fe\",\"placement_hash\":\"%s\",\"vast_config_url\":\"%s\"}\n", "d3bfc4a1c2f31ab987f2725a5ed03c9ae5837887", "https://get.truex.com/d3bfc4a1c2f31ab987f2725a5ed03c9ae5837887/vast/config?asnw=&flag=%2Bamcb%2Bemcr%2Bslcb%2Bvicb%2Baeti-exvt&fw_key_values=&metr=0&prof=g_as3_truex&ptgt=a&pvrn=&resp=vmap1&slid=fw_truex&ssnw=&vdur=&vprn=");
+            String json = String.format("{\"user_id\":\"3e47e82244f7aa7ac3fa60364a7ede8453f3f9fe\",\"placement_hash\":\"%s\",\"vast_config_url\":\"%s\"}\n", "81551ffa2b851abc5372ab9ed9f1f58adabe5203", "https://qa-get.truex.com/81551ffa2b851abc5372ab9ed9f1f58adabe5203/vast/config?asnw=&flag=%2Bamcb%2Bemcr%2Bslcb%2Bvicb%2Baeti-exvt&fw_key_values=&metr=0&prof=g_as3_truex&ptgt=a&pvrn=&resp=vmap1&slid=fw_truex&ssnw=&vdur=&vprn=");
             JSONObject adParams = new JSONObject(json);
 
             truexAdRenderer.init(adParams, TruexAdRendererConstants.PREROLL);


### PR DESCRIPTION
Sheppard was still referencing the previous maven repo, which is using the S3 endpoint that doesn't correctly report on missing files, leading to gradle build errors.

Also the tag utilized was not yet updated to match the tag we're using in supporting A&E's development effort.