### PR TITLE
Feature/ctv 2328 allow the standard options for the tar

### DIFF
--- a/Sheppard/build.gradle
+++ b/Sheppard/build.gradle
@@ -43,6 +43,6 @@ dependencies {
     // True[x] Ad Renderer (TAR) Dependency
     // Note: to refer to a local version of the TAR project, comment out the com.truex dependency
     // and uncomment the project one below.
-    implementation 'com.truex:TruexAdRenderer-tv:2.4.0'
+    implementation 'com.truex:TruexAdRenderer-tv:2.4.1'
     //implementation project(':TruexAdRenderer')
 }

--- a/Sheppard/src/main/java/com/truex/sheppard/ads/TruexAdManager.java
+++ b/Sheppard/src/main/java/com/truex/sheppard/ads/TruexAdManager.java
@@ -6,10 +6,12 @@ import android.view.ViewGroup;
 
 import com.truex.adrenderer.IEventEmitter.IEventHandler;
 import com.truex.adrenderer.TruexAdEvent;
+import com.truex.adrenderer.TruexAdOptions;
 import com.truex.adrenderer.TruexAdRenderer;
 import com.truex.sheppard.player.PlaybackHandler;
 
 import java.util.Map;
+import java.util.UUID;
 
 /**
  * This class holds a reference to the true[X] ad renderer and handles all of the event handling
@@ -49,7 +51,13 @@ public class TruexAdManager {
      */
     public void startAd(ViewGroup viewGroup) {
         String vastConfigUrl = "https://qa-get.truex.com/81551ffa2b851abc5372ab9ed9f1f58adabe5203/vast/config?asnw=&flag=%2Bamcb%2Bemcr%2Bslcb%2Bvicb%2Baeti-exvt&fw_key_values=&metr=0&prof=g_as3_truex&ptgt=a&pvrn=&resp=vmap1&slid=fw_truex&ssnw=&vdur=&vprn=";
-        truexAdRenderer.init(vastConfigUrl);
+
+        TruexAdOptions options = new TruexAdOptions();
+        options.supportsUserCancelStream = true;
+        //options.userAdvertisingId = "1234"; // for testing.
+        options.fallbackAdvertisingId = UUID.randomUUID().toString();
+
+        truexAdRenderer.init(vastConfigUrl, options);
         truexAdRenderer.start(viewGroup);
     }
 


### PR DESCRIPTION
### JIRA
https://truextech.atlassian.net/browse/CTV-2328

### Description
Allow the standard options on the TAR Android initializer

### Testing
Unit testing for TAR Android
Run end-to-end from Sheppard, examine options given to TAR HTML5 instance in the Chrome debugger.

### Commit Message Subject(s)
CTV-2328: Allow the standard options on the TAR Android initializer

### Additional Context
n/a

### Related PRs
firetv bridge: https://github.com/socialvibe/firetv-webview-webapp/pull/8
TAR Android: https://github.com/socialvibe/TruexAdRenderer-Android/pull/92
Sheppard: 

### Checks
- [x] Includes unit test coverage _(if applicable)_
- [x] Includes functional test coverage _(at feature-level, if applicable)_
- [x] Proposed commit messages follow [team conventions](https://github.com/socialvibe/adlabs-wiki/blob/develop/git/README.md#commits)
